### PR TITLE
Update to Minecraft 1.21.6 and expand configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
+minecraft_version=1.21.6
+yarn_mappings=1.21.6+build.1
 loader_version=0.18.4
 
 # Mod Properties
@@ -14,6 +14,6 @@ maven_group=xyz.devcomp
 archives_base_name=elytra-lock
 
 # Dependencies
-fabric_version=0.128.2+1.21.5
-yacl_version=3.8.1+1.21.5-fabric
-modmenu_version=14.0.0
+fabric_version=0.128.2+1.21.6
+yacl_version=3.8.1+1.21.6-fabric
+modmenu_version=15.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.6+build.1
 loader_version=0.18.4
 
 # Mod Properties
-mod_version=0.1.2
+mod_version=0.1.3
 maven_group=xyz.devcomp
 archives_base_name=elytra-lock
 

--- a/src/main/java/xyz/devcomp/elytralock/ElytraLock.java
+++ b/src/main/java/xyz/devcomp/elytralock/ElytraLock.java
@@ -8,12 +8,10 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
-import net.fabricmc.fabric.api.client.rendering.v1.HudLayerRegistrationCallback;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
-
 import xyz.devcomp.elytralock.config.ConfigHandler;
 import xyz.devcomp.elytralock.config.ConfigUtil;
 import xyz.devcomp.elytralock.events.ClientExitHandler;
@@ -46,10 +44,11 @@ public class ElytraLock implements ClientModInitializer {
 			LOGGER.warn("YACL_v3 is not loaded, not persisting elytra toggle");
 		}
 
-		HudLayerRegistrationCallback.EVENT.register(new HudRenderHandler());
 		ClientTickEvents.END_CLIENT_TICK.register(new ClientTickEndHandler());
 		ClientLifecycleEvents.CLIENT_STOPPING.register(new ClientExitHandler());
-		LOGGER.info("Registered HUD_RENDER, END_CLIENT_TICK and CLIENT_STOPPING events successfully!");
+		HudRenderHandler.register();
+
+		LOGGER.info("Registered END_CLIENT_TICK, CLIENT_STOPPING, and HUD render events successfully!");
 	}
 
 	public static boolean isLocked() {

--- a/src/main/java/xyz/devcomp/elytralock/ElytraLock.java
+++ b/src/main/java/xyz/devcomp/elytralock/ElytraLock.java
@@ -21,10 +21,10 @@ import xyz.devcomp.elytralock.events.HudRenderHandler;
 public class ElytraLock implements ClientModInitializer {
 	public static final Logger LOGGER = LoggerFactory.getLogger("Elytra Lock");
 	public static final FabricLoader LOADER = FabricLoader.getInstance();
-	private static KeyBinding lockKeybind;
-	private static boolean locked = false;
+
 	public static MinecraftClient client;
 	public static ConfigHandler config;
+	public static KeyBinding lockKeybind;
 
 	@Override
 	public void onInitializeClient() {
@@ -39,7 +39,6 @@ public class ElytraLock implements ClientModInitializer {
 		if (ConfigUtil.isYaclLoaded()) {
 			LOGGER.info("YACL_v3 is loaded, loading elytra toggle");
 			config = new ConfigHandler();
-			locked = config.getInstance().toggle;
 		} else {
 			LOGGER.warn("YACL_v3 is not loaded, not persisting elytra toggle");
 		}
@@ -52,10 +51,6 @@ public class ElytraLock implements ClientModInitializer {
 	}
 
 	public static boolean isLocked() {
-		if (lockKeybind.wasPressed()) {
-			locked = !locked;
-		}
-
-		return locked;
+		return config.getInstance().toggle;
 	}
 }

--- a/src/main/java/xyz/devcomp/elytralock/config/ConfigHandler.java
+++ b/src/main/java/xyz/devcomp/elytralock/config/ConfigHandler.java
@@ -10,7 +10,7 @@ import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
 
 public class ConfigHandler {
     private boolean isLoaded = false;
-    public static final ConfigClassHandler<ConfigModel> HANDLER = ConfigClassHandler.createBuilder(ConfigModel.class)
+    private static final ConfigClassHandler<ConfigModel> HANDLER = ConfigClassHandler.createBuilder(ConfigModel.class)
             .id(Identifier.of("elytralock", "config"))
             .serializer(config -> GsonConfigSerializerBuilder.create(config)
                     .setPath(ElytraLock.LOADER.getConfigDir().resolve("elytra-lock.json"))

--- a/src/main/java/xyz/devcomp/elytralock/config/ConfigModel.java
+++ b/src/main/java/xyz/devcomp/elytralock/config/ConfigModel.java
@@ -8,4 +8,9 @@ public class ConfigModel {
     @AutoGen(category = "elytralock")
     @TickBox
     public boolean toggle = false;
+
+    @SerialEntry(comment = "Whether fall flying (entering a flying state while jumping) should be prevented")
+    @AutoGen(category = "elytralock")
+    @TickBox
+    public boolean preventFallFlying = true;
 }

--- a/src/main/java/xyz/devcomp/elytralock/events/ClientTickEndHandler.java
+++ b/src/main/java/xyz/devcomp/elytralock/events/ClientTickEndHandler.java
@@ -24,6 +24,12 @@ public class ClientTickEndHandler implements EndTick {
     public void onEndTick(MinecraftClient client) {
         if (client.player != null) {
             impl.run(client);
+
+            // Update the config state to reflect the real lock state
+            var instance = ElytraLock.config.getInstance();
+            if (ElytraLock.lockKeybind.wasPressed()) {
+                instance.toggle = !instance.toggle;
+            }
         }
     }
 }

--- a/src/main/java/xyz/devcomp/elytralock/events/HudRenderHandler.java
+++ b/src/main/java/xyz/devcomp/elytralock/events/HudRenderHandler.java
@@ -1,28 +1,27 @@
 package xyz.devcomp.elytralock.events;
 
-import net.fabricmc.fabric.api.client.rendering.v1.HudLayerRegistrationCallback;
-import net.fabricmc.fabric.api.client.rendering.v1.IdentifiedLayer;
-import net.fabricmc.fabric.api.client.rendering.v1.LayeredDrawerWrapper;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElement;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.client.util.Window;
 import net.minecraft.util.Arm;
 import net.minecraft.util.Identifier;
 import xyz.devcomp.elytralock.ElytraLock;
 
-public class HudRenderHandler implements HudLayerRegistrationCallback {
+public class HudRenderHandler implements HudElement {
     public static final int WIDTH = 16;
     public static final int HEIGHT = 16;
     private static final Identifier LAYER_ID = Identifier.of("elytralock", "toggle-status-indicator");
 
-    @Override
-    public void register(LayeredDrawerWrapper layeredDrawer) {
-        layeredDrawer.attachLayerAfter(IdentifiedLayer.HOTBAR_AND_BARS, LAYER_ID, HudRenderHandler::render);
+    public static void register() {
+        HudElementRegistry.attachElementAfter(VanillaHudElements.HOTBAR, LAYER_ID, new HudRenderHandler());
     }
 
-    private static void render(DrawContext context, RenderTickCounter tickCounter) {
+    public void render(DrawContext context, RenderTickCounter tickCounter) {
         if (!MinecraftClient.isHudEnabled())
             return;
 
@@ -39,7 +38,7 @@ public class HudRenderHandler implements HudLayerRegistrationCallback {
         Window window = ElytraLock.client.getWindow();
         int width = window.getScaledWidth(), height = window.getScaledHeight();
 
-        context.drawTexture(RenderLayer::getGuiTextured, icon, (width / 2) + offset, height - HEIGHT - 3, 0, 0, WIDTH,
+        context.drawTexture(RenderPipelines.GUI_TEXTURED, icon, (width / 2) + offset, height - HEIGHT - 3, 0, 0, WIDTH,
                 HEIGHT, WIDTH, HEIGHT);
     }
 }

--- a/src/main/java/xyz/devcomp/elytralock/mixin/PlayerEntityMixin.java
+++ b/src/main/java/xyz/devcomp/elytralock/mixin/PlayerEntityMixin.java
@@ -12,10 +12,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.entity.player.PlayerEntity;
 
-// TODO: In the future, make fall flying prevention and elytra lock separate
-// Fall flying prevention should be subset of elytra locking which should be 
-// individually toggleable
-
 @Mixin(PlayerEntity.class)
 public class PlayerEntityMixin {
     private static RunOnceOnToggle<String> logOnce = new RunOnceOnToggle<String>(
@@ -27,7 +23,8 @@ public class PlayerEntityMixin {
 
     @Inject(method = "checkGliding()Z", at = @At("HEAD"), cancellable = true)
     private void preventFallFlying(CallbackInfoReturnable<Boolean> info) {
-        if (logOnce.run("Elytra is locked, so preventing fall flying"))
+        var config = ElytraLock.config.getInstance();
+        if (config.preventFallFlying && logOnce.run("Elytra is locked, so preventing fall flying"))
             info.setReturnValue(false);
     }
 }

--- a/src/main/resources/assets/elytra-lock/lang/en_us.json
+++ b/src/main/resources/assets/elytra-lock/lang/en_us.json
@@ -3,5 +3,6 @@
     "key.elytralock.lock": "Lock elytra",
     "elytralock.chat.lockedMessage": "[§e§lelytra-lock§r] Elytra is §olocked§r!",
     "yacl3.config.elytralock:config.toggle": "Toggle Elytra Lock",
+    "yacl3.config.elytralock:config.preventFallFlying": "Prevent Fall Flying",
     "yacl3.config.elytralock:config.category.elytralock": "Elytra Lock"
 }


### PR DESCRIPTION
Updates required dependencies, adds support for 1.21.6, and brings along two improvements to the configuration system:

- Fall flying prevention is now an optional and toggleable setting
- The lock toggle setting in the menu reflects the actual state, alongside the HUD indicator
